### PR TITLE
spawn: prevent core dump in case of misuse

### DIFF
--- a/src/spawn.c
+++ b/src/spawn.c
@@ -36,11 +36,17 @@ int spawn_open(lua_State *L) {
 
    lua_pushstring(L, "file");
    lua_gettable(L, 1);
+   if (lua_type(L, -1) != LUA_TSTRING) {
+      return LUA_HANDLE_ERROR_STR(L, "file: expected a string");
+   }
    const char *file = lua_tostring(L, -1);
    lua_pop(L, 1);
 
    lua_pushstring(L, "args");
    lua_gettable(L, 1);
+   if (lua_type(L, -1) != LUA_TNIL && lua_type(L, -1) != LUA_TTABLE) {
+      return LUA_HANDLE_ERROR_STR(L, "args: expected a table, or nil");
+   }
    size_t n = lua_objlen(L, -1);
    char **argv = alloca(sizeof(char *) * (n + 2));
    argv[0] = (char *)file;

--- a/test/test_spawn.lua
+++ b/test/test_spawn.lua
@@ -153,4 +153,25 @@ test {
       assert(ok == false)
       collectgarbage()
    end,
+
+   testMisuse = function()
+      local ok, msg
+
+      ok, msg = pcall(function()
+         local p = ipc.spawn({
+            file = 'echo',
+            args = 'what', -- should be a table
+         })
+      end)
+      assert(ok == false)
+      assert(string.find(msg, "expected a table"))
+
+      ok, msg = pcall(function()
+         local p = ipc.spawn({
+            file = function() return 'echo' end, -- should be a string
+         })
+      end)
+      assert(ok == false)
+      assert(string.find(msg, "expected a string"))
+   end,
 }


### PR DESCRIPTION
Encountered this by mistake, e.g.:

```
th> ipc = require 'libipc'
th> ipc.spawn{file='curl', args='--version'}
Segmentation fault (core dumped)
```
