### PR TITLE
variable t must be of type time_t

### DIFF
--- a/src/cliser.c
+++ b/src/cliser.c
@@ -298,7 +298,7 @@ int cliser_client(lua_State *L) {
    if (ret) return ret;
    struct timeval tv;
    gettimeofday(&tv, NULL);
-   uint32_t t = tv.tv_sec + DEFAULT_TIMEOUT_SECONDS;
+   time_t t = tv.tv_sec + DEFAULT_TIMEOUT_SECONDS;
    int sock = -1;
    while (tv.tv_sec < t) {
       ret = socket(PF_INET, SOCK_STREAM, 0);


### PR DESCRIPTION
`time_t` can be defined as signed int on some platforms (e.g. my 32-bit ubuntu 14.04 with libc 2.19 and gcc 4.8.4), generating compilation error when being compared with `uint32_t`.

It would be more correct to define `t` the same type as `tv.tv_sec`, i.e. `time_t`.
