### PR TITLE
added support for (de)serializing closures/upvalues

### DIFF
--- a/doc/BackgroundTask.md
+++ b/doc/BackgroundTask.md
@@ -63,3 +63,7 @@ use curl to upload the saved file to a hypothetical website.
    local ret,t = background.getResults()
    print('curl returned  '..ret..' in '..t..' seconds')
 ```
+
+Note that __ipc.BackgroundTask__ will throw an error when attempting to serialize closures/upvalues.
+However [ipc.workqueue](workqueue.md) provides __:writeup()__ for serializing closures/upvalues.
+

--- a/doc/BackgroundTaskPool.md
+++ b/doc/BackgroundTaskPool.md
@@ -41,3 +41,6 @@ error.
       assert(pool.getResult(i) == math.sqrt(i))
    end
 ```
+
+Note that __ipc.BackgroundTaskPool__ will throw an error when attempting to serialize closures/upvalues.
+However [ipc.workqueue](workqueue.md) provides __:writeup()__ for serializing closures/upvalues.

--- a/doc/map.md
+++ b/doc/map.md
@@ -33,6 +33,9 @@ threads have died. The __:checkErrors()__ function will bubble
 up an errors. You can wrap this in a pcall if you think the
 error is recoverable (generally, it is not).
 
+Note that __ipc.map()__ will throw an error when attempting to serialize closures/upvalues.
+However [ipc.workqueue](workqueue.md) provides __:writeup()__ for serializing closures/upvalues.
+
 Most often [ipc.map](map.md) is combined with an [ipc.workqueue](workqueue.md)
 in order to distribute work across the threads.
 A more concrete example of combining [ipc.map](map.md) and [ipc.workqueue](workqueue.md)

--- a/doc/workqueue.md
+++ b/doc/workqueue.md
@@ -71,11 +71,10 @@ However, we do provide __:writeup()__ for serializing closures/upvalues.
 So calling __:writeup(closure)__ will not fail.
 
 In Lua, almost everything is an upvalues. 
-For example, the `nn` variable is an upvalue in the following `closure()`:
+For example, the `nn` variable is an upvalue in the following `heavyclosure()`:
 
 ```lua
-local nn = require 'nn'
-
+local nn = require 'nn' -- upvalue
 local heavyclosure = function(input)
    return nn.Linear:forward(input)
 end
@@ -93,8 +92,10 @@ end
 
 Calling __:write(lightfunction)__ will be much more efficient.
 
-As a final note on __:writeup()__, for the powerusers out there, note that we do not serialize the `_ENV` upvalue of closures.
-Typically `_ENV = _G` in the writing thread, which would be too heavy to serialize. So instead we set the deserialized `_ENV` to the reading threads `_G`.
+As a final note for the powerusers out there, know that _:writeup()__ does not serialize the `_ENV` upvalue of closures.
+Typically `_ENV = _G` in the writing thread, which would be too heavy to serialize. 
+Instead we set the `_ENV` upvalue of the deserialized closure to the reading threads `_G`.
+So if you dont see any `_ENV` in your code, you should be fine.
 
 ### multi-write
 

--- a/doc/workqueue.md
+++ b/doc/workqueue.md
@@ -3,10 +3,11 @@
 Creating an [ipc.workqueue](workqueue.md) allows a thread to communicate with a set of
 worker threads created by [ipc.map](map.md). The queue is bidirectional between
 an owner thread and the workers. All native Lua types can be quickly marshaled
-by value across thread boundaries (a copy is made). Torch Tensor and Storage
-objects are marshaled by reference (no copy is made).
+by value across thread boundaries (a copy is made). 
+Torch [Tensor](https://github.com/torch/torch7/blob/master/doc/tensor.md#tensor) 
+and Storage objects are marshaled by reference (no copy is made).
 
-The two main functions are __:write()__ and __:read(). Their usage depends
+The two main functions are __:write()__ and __:read()__. Their usage depends
 on the perspective of the caller. From the owner thread's perspective,
 __:write()__ will put a *question* on the queue for one of the workers to process.
 Whenever the owner thread would like get the *answer* it can call __:read()__.
@@ -52,6 +53,55 @@ This is useful to poll for *answers* while doing other work.
 Passing *true* into __:read(true)__ will check the queue for
 an answer, if one is ready it will return it, else __:read(true)__
 will return nil, indicating no *answer* is currently ready.
+
+### `writeup()`
+
+Lua supports closures. These are functions with upvalues, i.e. non-global variables outside the scope of the function:
+
+```lua
+local upvalue = 1
+local closure = function()
+   return upvalue
+end
+```
+
+By default __:write()__ doesn't support closures. Calling __:write(closure)__ will throw an error.
+The reason for this is that we want to discourage users from serializing upvalues unless they absolutely need to.
+However, we do provide __:writeup()__ for serializing closures/upvalues. 
+So calling __:writeup(closure)__ will not fail.
+
+In Lua, almost everything is an upvalues. 
+For example, the `nn` variable is an upvalue in the following `closure()`:
+
+```lua
+local nn = require 'nn'
+
+local heavyclosure = function(input)
+   return nn.Linear:forward(input)
+end
+```
+
+Calling __:writeup(heavyclosure)__ will attempt to serialize the entire `nn` package. 
+To avoid this kind of mistake, we recommend calling require from inside the closure:
+
+```lua
+local lightfunction = function(input)
+   local nn = require 'nn'
+   return nn.Linear:forward(input)
+end
+```
+
+Calling __:write(lightfunction)__ will be much more efficient.
+
+As a final note on __:writeup()__, for the powerusers out there, note that we do not serialize the `_ENV` upvalue of closures.
+Typically `_ENV = _G` in the writing thread, which would be too heavy to serialize. So instead we set the deserialized `_ENV` to the reading threads `_G`.
+
+### multi-write
+
+The __:write()__ and __:writeup()__ methods can be used to write multiple objects into the queue at once.
+For example, `q:write(1, 2, 3)` is equivalent to `q:write(1);q:write(2);q:write(3)`.
+As such, each argument passed to __:write()__  and __:writeup()__ will require their own `q:read()` to be read.
+
 
 A more concrete example of combining [ipc.map](map.md) and [ipc.workqueue](workqueue.md)
 can be found in [ipc.BackgroundTask](BackgroundTask.md)

--- a/src/cliser.c
+++ b/src/cliser.c
@@ -523,7 +523,7 @@ static int sock_recv_raw(lua_State *L, int sock, void *ptr, size_t len, copy_con
 
 static int sock_send_msg(lua_State *L, int index, int sock, ringbuffer_t *rb, copy_context_t *copy_context) {
    ringbuffer_push_write_pos(rb);
-   int ret = rb_save(L, index, rb, 1);
+   int ret = rb_save(L, index, rb, 1, 0);
    if (ret) return LUA_HANDLE_ERROR(L, ret);
    size_t len = ringbuffer_peek(rb);
    ringbuffer_pop_write_pos(rb);

--- a/src/ipc.c
+++ b/src/ipc.c
@@ -84,6 +84,7 @@ static const struct luaL_Reg workqueue_routines[] = {
    {"close", workqueue_close},
    {"read", workqueue_read},
    {"write", workqueue_write},
+   {"writeup", workqueue_writeup},
    {"drain", workqueue_drain},
    {NULL, NULL}
 };

--- a/src/map.c
+++ b/src/map.c
@@ -31,7 +31,7 @@ ThreadInitFunc _ipc_static_init_thread = NULL;
 static int rb_save_with_growth(lua_State *L, int index, struct ringbuffer_t *rb) {
    while (1) {
       ringbuffer_push_write_pos(rb);
-      int ret = rb_save(L, index, rb, 0);
+      int ret = rb_save(L, index, rb, 0, 0); // map doesn't support upvalues
       if (ret == -ENOMEM) {
          ringbuffer_pop_write_pos(rb);
          ringbuffer_grow_by(rb, MAX_ARG_SIZE);
@@ -63,7 +63,7 @@ static void* thread_func(void *arg) {
    }
    map_thread->ret = lua_pcall(L, 0, 0, 0);
    if (map_thread->ret) {
-      fprintf(stderr, "WARN: ipc.map thread pcall failed: %s\n", lua_tostring(L, -1));
+      fprintf(stderr, "WARN1: ipc.map thread pcall failed: %s\n", lua_tostring(L, -1));
    } else {
       top = lua_gettop(L);
       int i = 0;
@@ -73,7 +73,7 @@ static void* thread_func(void *arg) {
       }
       map_thread->ret = lua_pcall(L, i - 1, LUA_MULTRET, 0);
       if (map_thread->ret) {
-         fprintf(stderr, "WARN: ipc.map thread pcall failed: %s\n", lua_tostring(L, -1));
+         fprintf(stderr, "WARN2: ipc.map thread pcall failed: %s\n", lua_tostring(L, -1));
       }
    }
    int k = lua_gettop(L) - top;

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -94,12 +94,12 @@ int rb_save(lua_State *L, int index, ringbuffer_t *rb, int oop) {
          int top = lua_gettop(L);
          lua_pushnil(L);
          while (lua_next(L, index) != 0) {
-            int ret = rb_save(L, top + 1, rb, oop);
+            int ret = rb_save(L, top + 1, rb, oop); // key
             if (ret) {
                lua_pop(L, 2);
                return ret;
             }
-            ret = rb_save(L, top + 2, rb, oop);
+            ret = rb_save(L, top + 2, rb, oop); // value
             if (ret) {
                lua_pop(L, 2);
                return ret;
@@ -115,6 +115,13 @@ int rb_save(lua_State *L, int index, ringbuffer_t *rb, int oop) {
          if (index != lua_gettop(L)) {
             lua_pushvalue(L, index);
          }
+         lua_Debug ar;
+         lua_pushvalue(L, -1);
+         lua_getinfo(L, ">nuS", &ar);
+         if (ar.what[0] != 'L') {
+             luaL_error(L, "attempt to persist a C function '%s'", ar.name);
+         }
+         
          // this returns different things under LuaJIT vs Lua
 #if LUA_VERSION_NUM >= 503
          lua_dump(L, rb_lua_writer, rb, 0);
@@ -124,8 +131,32 @@ int rb_save(lua_State *L, int index, ringbuffer_t *rb, int oop) {
          if (index != lua_gettop(L)) {
             lua_pop(L, 1);
          }
+
          size_t str_len = 0;
-         RB_WRITE(L, rb, &str_len, sizeof(size_t));
+         RB_WRITE(L, rb, &str_len, sizeof(size_t)); // zero-terminated
+         
+         // upvalues
+         lua_newtable(L);
+         int envIdx = -1;
+         for (int i=1; i <= ar.nups; i++) {
+            const char *name = lua_getupvalue(L, -2, i);
+            if (strcmp(name, "_ENV") != 0) { 
+               lua_rawseti(L, -2, i);
+            } else { // ignore _ENV as we assume that this is the global _G variable
+               lua_pop(L, 1);
+               envIdx = i;
+            }
+         }
+         // write upvalue index of _ENV
+         RB_WRITE(L, rb, &envIdx, sizeof(envIdx));
+
+         // write upvalue table
+         int ret = rb_save(L, lua_gettop(L), rb, oop);
+         lua_pop(L, 1);
+         if (ret) {
+            return ret;
+         }
+
          return 0;
       }
       case LUA_TUSERDATA: {
@@ -196,9 +227,9 @@ static int rb_load_rcsv(lua_State *L, ringbuffer_t *rb, int is_key) {
       case LUA_TTABLE:
          lua_newtable(L);
          while (1) {
-            ret = rb_load_rcsv(L, rb, 1);
+            ret = rb_load_rcsv(L, rb, 1); // key
             if (!ret) break;
-            rb_load_rcsv(L, rb, 0);
+            rb_load_rcsv(L, rb, 0); // value
             lua_settable(L, -3);
          }
          return 1;
@@ -210,11 +241,37 @@ static int rb_load_rcsv(lua_State *L, ringbuffer_t *rb, int is_key) {
 #else
          ret = lua_load(L, rb_lua_reader, &chunked, NULL, NULL);
 #endif
+
          if (ret) return -EINVAL;
          // LuaJIT reads the last 0 marker, regular Lua does not, even it out.
          if (!chunked.read_last) {
             RB_READ(L, rb, &str_len, sizeof(str_len));
          }
+
+         // read upvalue index of _ENV
+         int envIdx;
+         RB_READ(L, rb, &envIdx, sizeof(envIdx));
+
+         // read table of upvalues
+         rb_load_rcsv(L, rb, 0);
+
+         // set _ENV
+         if (envIdx > 0) {
+            lua_getglobal(L, "_G");
+            lua_setupvalue(L, -3, envIdx);
+         }
+
+         // set function upvalues
+         int top = lua_gettop(L);
+         lua_pushnil(L);
+         while (lua_next(L, top) != 0) {
+            lua_Integer n = lua_tointeger(L, top + 1); // key
+            lua_setupvalue(L, -4, n);
+         }
+
+         lua_pop(L, 1);
+
+         
          return 1;
       case LUA_TUSERDATA:
       case -LUA_TUSERDATA:

--- a/src/serialize.c
+++ b/src/serialize.c
@@ -111,6 +111,7 @@ int rb_save(lua_State *L, int index, ringbuffer_t *rb, int oop) {
          return 0;
       }
       case LUA_TFUNCTION: {
+
          RB_WRITE(L, rb, &type, sizeof(char));
          if (index != lua_gettop(L)) {
             lua_pushvalue(L, index);
@@ -128,9 +129,6 @@ int rb_save(lua_State *L, int index, ringbuffer_t *rb, int oop) {
 #else
          lua_dump(L, rb_lua_writer, rb);
 #endif
-         if (index != lua_gettop(L)) {
-            lua_pop(L, 1);
-         }
 
          size_t str_len = 0;
          RB_WRITE(L, rb, &str_len, sizeof(size_t)); // zero-terminated
@@ -153,6 +151,11 @@ int rb_save(lua_State *L, int index, ringbuffer_t *rb, int oop) {
          // write upvalue table
          int ret = rb_save(L, lua_gettop(L), rb, oop);
          lua_pop(L, 1);
+
+         if (index != lua_gettop(L)) {
+            lua_pop(L, 1);
+         }
+
          if (ret) {
             return ret;
          }

--- a/src/serialize.h
+++ b/src/serialize.h
@@ -5,6 +5,6 @@
 #include "ringbuffer.h"
 
 int rb_load(lua_State *L, struct ringbuffer_t *rb);
-int rb_save(lua_State *L, int index, struct ringbuffer_t *rb, int oop);
+int rb_save(lua_State *L, int index, struct ringbuffer_t *rb, int oop, int upval);
 
 #endif

--- a/src/workqueue.h
+++ b/src/workqueue.h
@@ -7,6 +7,7 @@ int workqueue_open(lua_State *L);
 int workqueue_close(lua_State *L);
 int workqueue_read(lua_State *L);
 int workqueue_write(lua_State *L);
+int workqueue_writeup(lua_State *L);
 int workqueue_drain(lua_State *L);
 
 #endif

--- a/test/test_workqueue.lua
+++ b/test/test_workqueue.lua
@@ -1,11 +1,12 @@
 local test = require 'regress'
 local ipc = require 'libipc'
 
-local q = ipc.workqueue('test')
+local name = 'test'
+local q = ipc.workqueue(name)
 
-local echo = ipc.map(1, function()
+local echo = ipc.map(1, function(name)
    local ipc = require 'libipc'
-   local q = ipc.workqueue('test')
+   local q = ipc.workqueue(name)
    while true do
       local msg = q:read()
       if msg == nil then
@@ -20,7 +21,7 @@ local echo = ipc.map(1, function()
       q:write(msg)
    end
    q:close()
-end)
+end, "test")
 
 local function tableEq(t0, t1)
    for k,v in pairs(t0) do

--- a/test/test_workqueue.lua
+++ b/test/test_workqueue.lua
@@ -99,6 +99,22 @@ test {
       test.mustBeTrue(n == n1, 'Function serialization failed '..n..' ~= '..n1)
    end,
 
+   testClosures = function()
+      if f3rtwertwert534 ~= nil then
+         return
+      end
+      -- global function with an unlikely name
+      f3rtwertwert534 = function() return 534 end
+      local bias1, bias2, bias3 = 0, 1, 2
+      local f0 = function() return f3rtwertwert534() + bias3 end
+      local f = function(a, b, c) return f0() + bias2 + bias1 + math.sqrt((a * a) + (b * b) + (c * c)) end
+      q:write(f)
+      local f1 = q:read()
+      local n = f(1, 2, 3)
+      local n1 = f1(1, 2, 3)
+      test.mustBeTrue(n == n1, 'Function serialization failed '..n..' ~= '..n1)
+      f3rtwertwert534 = nil
+   end,
    testTensors = function()
       local f = torch.randn(10)
       q:write(f)


### PR DESCRIPTION
fixes #28 for Lua 5.2. This won't work with LuaJIT (pretty sure, though untested).

 * [x] ipc.workqueue.writeup() to write upvalues
 * [x] unit test on LuaJIT
 * [x] documentation
  * [x] writeup: how to use and not use upvalues
  * [x] write: multi-write is not documented
