### PR TITLE
Serialize tables having metatables

### DIFF
--- a/test/test_workqueue.lua
+++ b/test/test_workqueue.lua
@@ -14,7 +14,7 @@ local echo = ipc.map(1, function(name)
       else
          if msg == nil then
             break
-         elseif torch.typename(msg) then
+         elseif torch.isTensor(msg) then
             if msg:size(1) == 1 then
                msg:fill(13)
             end
@@ -92,6 +92,21 @@ test {
       q:write(n)
       local n1 = q:read()
       local e, msg = tableEq(n, n1)
+      test.mustBeTrue(e, 'Table serialization failed '..msg)
+   end,
+
+   testMetaTables = function()
+      local class = torch.class("torch.asdfasdfa")
+      local cmd = torch.asdfasdfa()
+      local cmd = torch.CmdLine()
+      cmd.id = 1234
+      cmd.cmd = torch.CmdLine()
+      q:write(cmd)
+      local cmd1 = q:read()
+      test.mustBeTrue(torch.typename(cmd) == torch.typename(cmd1), "Metatable serialization failed")
+      test.mustBeTrue(torch.typename(cmd.cmd) == torch.typename(cmd1.cmd), "Metatable nested serialization failed")
+      test.mustBeTrue(cmd.id == 1234, "Metatable table serialize fail")
+      local e, msg = tableEq(cmd, cmd1)
       test.mustBeTrue(e, 'Table serialization failed '..msg)
    end,
 

--- a/test/test_workqueue.lua
+++ b/test/test_workqueue.lua
@@ -6,6 +6,8 @@ local q = ipc.workqueue(name)
 
 local echo = ipc.map(1, function(name)
    local ipc = require 'libipc'
+   local lib = {}
+   local class = torch.class("lib.class", lib)
    local q = ipc.workqueue(name)
    while true do
       local msg = q:read()
@@ -14,6 +16,8 @@ local echo = ipc.map(1, function(name)
       else
          if msg == nil then
             break
+         elseif torch.type(msg) == 'lib.class' then
+            msg.reply = true
          elseif torch.isTensor(msg) then
             if msg:size(1) == 1 then
                msg:fill(13)
@@ -96,16 +100,23 @@ test {
    end,
 
    testMetaTables = function()
-      local class = torch.class("torch.asdfasdfa")
-      local cmd = torch.asdfasdfa()
+      -- local module class
+      local lib = {}
+      local class = torch.class('lib.class', lib)
+      local cmd = lib.class()
+      q:write(cmd)
+      local cmd1 = q:read()
+      test.mustBeTrue(torch.typename(cmd) == torch.typename(cmd1), "local Metatable serialization failed")
+      test.mustBeTrue(cmd1.reply, "local Metatable table serialize fail")
+      -- global module class
       local cmd = torch.CmdLine()
       cmd.id = 1234
       cmd.cmd = torch.CmdLine()
       q:write(cmd)
       local cmd1 = q:read()
-      test.mustBeTrue(torch.typename(cmd) == torch.typename(cmd1), "Metatable serialization failed")
-      test.mustBeTrue(torch.typename(cmd.cmd) == torch.typename(cmd1.cmd), "Metatable nested serialization failed")
-      test.mustBeTrue(cmd.id == 1234, "Metatable table serialize fail")
+      test.mustBeTrue(torch.typename(cmd) == torch.typename(cmd1), "global Metatable serialization failed")
+      test.mustBeTrue(torch.typename(cmd.cmd) == torch.typename(cmd1.cmd), "global Metatable nested serialization failed")
+      test.mustBeTrue(cmd.id == 1234, "global Metatable table serialize fail")
       local e, msg = tableEq(cmd, cmd1)
       test.mustBeTrue(e, 'Table serialization failed '..msg)
    end,


### PR DESCRIPTION
This PR adds functionality to serialize tables having metatables. This includes objects instantiated with classes created via torch.class(). As expected, the metatable is NOT serialized. Includes unit tests for serializing objects from classes contained in both local and global modules.