### PR TITLE
fix ringbuffer growth bug

### DIFF
--- a/src/serialize.c
+++ b/src/serialize.c
@@ -52,6 +52,12 @@ static const char *rb_lua_reader(lua_State *L, void *param, size_t *size) {
    return NULL;
 }
 
+inline static void rb_stackCheck(lua_State *L, int startsize, const char* loc) {
+   if (lua_gettop(L) != startsize) {
+      luaL_error(L, "Stack wasn't correctly reset in %s\n", loc);
+   }
+}
+
 int rb_save(lua_State *L, int index, ringbuffer_t *rb, int oop, int upval) {
    char type = lua_type(L, index);
    switch (type) {
@@ -90,6 +96,7 @@ int rb_save(lua_State *L, int index, ringbuffer_t *rb, int oop, int upval) {
          return 0;
       }
       case LUA_TTABLE: {
+         int startsize = lua_gettop(L);
          RB_WRITE(L, rb, &type, sizeof(char));
          int top = lua_gettop(L);
          int ret;
@@ -99,17 +106,19 @@ int rb_save(lua_State *L, int index, ringbuffer_t *rb, int oop, int upval) {
             ret = rb_save(L, top + 1, rb, oop, upval); // key
             if (ret) {
                lua_pop(L, 2);
+               rb_stackCheck(L, startsize, "write table key");
                return ret;
             }
             ret = rb_save(L, top + 2, rb, oop, upval); // value
             if (ret) {
                lua_pop(L, 2);
+               rb_stackCheck(L, startsize, "write table key");
                return ret;
             }
             lua_pop(L, 1);
          }
          type = LUA_TNIL;
-         RB_WRITE(L, rb, &type, sizeof(char)); // breaks the read loop
+         RB_WRITE(L, rb, &type, sizeof(char)); // nil breaks the read loop
 
          // the typename identifies the metatable
          const char *str = luaT_typename(L, index);
@@ -124,12 +133,13 @@ int rb_save(lua_State *L, int index, ringbuffer_t *rb, int oop, int upval) {
          size_t str_len = strlen(str);
          RB_WRITE(L, rb, &str_len, sizeof(str_len));
          RB_WRITE(L, rb, str, str_len);
+         rb_stackCheck(L, startsize, "write table return");
          return 0;
       }
       case LUA_TFUNCTION: {
-
+         int startsize = lua_gettop(L);
          RB_WRITE(L, rb, &type, sizeof(char));
-         if (index != lua_gettop(L)) {
+         if (index != startsize) {
             lua_pushvalue(L, index);
          }
          lua_Debug ar;
@@ -171,6 +181,8 @@ int rb_save(lua_State *L, int index, ringbuffer_t *rb, int oop, int upval) {
             // write upvalue table
             int ret = rb_save(L, lua_gettop(L), rb, oop, upval);
             if (ret) {
+               lua_pop(L, 1);
+               rb_stackCheck(L, startsize, "write function upvalue");
                return ret;
             }
             lua_pop(L, 1);
@@ -181,7 +193,7 @@ int rb_save(lua_State *L, int index, ringbuffer_t *rb, int oop, int upval) {
          if (index != lua_gettop(L)) {
             lua_pop(L, 1);
          }
-
+         rb_stackCheck(L, startsize, "write function return");
          return 0;
       }
       case LUA_TUSERDATA: {

--- a/src/workqueue.c
+++ b/src/workqueue.c
@@ -188,7 +188,8 @@ int workqueue_read(lua_State *L) {
 
 static int workqueue_queue_write(lua_State *L, int index, queue_t *queue, int upval) {
    pthread_mutex_lock(&queue->mutex);
-   while (index <= lua_gettop(L)) {
+   int top = lua_gettop(L);
+   while (index <= top) {
       ringbuffer_push_write_pos(queue->rb);
       int ret = rb_save(L, index, queue->rb, 0, upval);
       if (ret == -ENOMEM) {


### PR DESCRIPTION
This fixes a bug where when the ringbuffer grows, not everything was removed from the stack. It was quite obscure to detect and understand. To prevent somebody else from making the same mistakes, I added the rb_stackCheck function. 