### PR TITLE
Better closure error message

### DIFF
--- a/src/map.c
+++ b/src/map.c
@@ -64,7 +64,7 @@ static int start_thread(void* arg, map_thread_t **map_thread, lua_State **L, int
    }
    (*map_thread)->ret = lua_pcall(*L, 0, 0, 0);
    if ((*map_thread)->ret) {
-      fprintf(stderr, "WARN: ipc.%s thread pcall failed: %s\n", name, lua_tostring(*L, -1));
+      fprintf(stderr, "WARN1: ipc.%s thread pcall failed: %s\n", name, lua_tostring(*L, -1));
       return 0;
    } else {
       return 1;
@@ -92,7 +92,7 @@ static void core_thread(map_thread_t *map_thread, lua_State *L, const char *name
    }
    map_thread->ret = lua_pcall(L, i - 1, LUA_MULTRET, 0);
    if (map_thread->ret) {
-      fprintf(stderr, "WARN: ipc.%s thread pcall failed: %s\n", name, lua_tostring(L, -1));
+      fprintf(stderr, "WARN2: ipc.%s thread pcall failed: %s\n", name, lua_tostring(L, -1));
    }
 }
 

--- a/test/test_map.lua
+++ b/test/test_map.lua
@@ -56,6 +56,36 @@ test {
       test.mustBeTrue(type(msg) == 'string', 'expected the error message to be a string')
    end,
 
+   testUpvalueError = function()
+      Global4523463456345 = 32 -- set a global
+      local function envIsSet()
+         return Global4523463456345 == nil and 56
+      end
+      local name, value = debug.getupvalue(envIsSet, 1)
+      local res = ipc.map(1, envIsSet):join()
+      test.mustBeTrue(res == 56)
+
+      local function envIsSet2()
+         Global4523463456345 = 46
+         local function envIsSet()
+            return Global4523463456345
+         end
+         return envIsSet()
+      end
+      local res = ipc.map(1, envIsSet2):join()
+      test.mustBeTrue(res == 46)
+
+      Global4523463456345 = nil
+
+      local i,j=1,2
+      local function closure()
+         return i+j+1
+      end
+      local ok, msg = pcall(function() ipc.map(1, closure):join() end)
+      test.mustBeTrue(ok == false, 'expected the map to fail')
+      test.mustBeTrue(type(msg) == 'string', 'expected the error message to be a string')
+   end,
+
    testCheckErrors = function()
       local m = ipc.map(2, function(idx)
          local sys = require 'sys'


### PR DESCRIPTION
This PR makes it easier to debug those pesky upvalue serialization cases. 
When serializing a closure, the following error message would be printed:
```lua
Attempt to serialize closure 'test/test_map.lua:81' with 2 upvalues; first is: 'i'.
Consider using ipc.workqueue.writeup() instead.	
```
where `test/test_map.lua:81` points to the function with upvalues.

Also fixes a bug identified by @pavanky where a single upvalue (excluding _ENV) would not generate an error message.